### PR TITLE
improve speed of team user lookup

### DIFF
--- a/gh_org_mgr/_gh_org.py
+++ b/gh_org_mgr/_gh_org.py
@@ -41,6 +41,13 @@ class GHorg:  # pylint: disable=too-many-instance-attributes
         self.gh = Github(get_github_token(token))
         self.org = self.gh.get_organization(orgname)
 
+    def ratelimit(self):
+        """Get current rate limit"""
+        core = self.gh.get_rate_limit().core
+        logging.debug(
+            "Current rate limit: %s/%s (reset: %s)", core.remaining, core.limit, core.reset
+        )
+
     def df2json(self) -> str:
         """Convert the dataclass to a JSON string"""
         d = asdict(self)

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -43,10 +43,20 @@ def main():
         )
         sys.exit(1)
 
+    # Login to GitHub with token, get GitHub organisation
     org.login(cfg_org.get("org_name", ""), cfg_app.get("github_token", ""))
+    # Get current rate limit
+    org.ratelimit()
+
+    # Create teams that aren't present at Github yet
     org.create_missing_teams(dry=args.dry)
+    # Synchronise the team memberships
     org.sync_teams_members(dry=args.dry)
+    # Report about organisation members that do not belong to any team
     org.get_members_without_team()
+    # Synchronise the permissions of teams for all repositories
     org.sync_repo_permissions(dry=args.dry)
 
+    # Debug output
     logging.debug("Final dataclass:\n%s", org.df2json())
+    org.ratelimit()


### PR DESCRIPTION
Fixes #12 

With the OpenRail data, it reduces the API calls from 180 to 143, so 37 calls saved. It reduces the time needed for a whole run from 77 seconds to 60 seconds, so 17 seconds saved.

In organisations with less sub-teams, the advantage will even be higher, as we spend a lot of calls for `.has_in_members()`.