### PR TITLE
Synchronise team settings

### DIFF
--- a/config/example/org.yaml
+++ b/config/example/org.yaml
@@ -11,8 +11,15 @@ org_name: example-org-on-github
 org_owners:
   - octocat
 
-# Default settings
+# Default settings. Will be overridden if set in a team.
+# If neither defaults nor team settings are present:
+# - when creating a new team, will take GitHub's defaults.
+# - when syncing settting of a team, will not touch the current status.
 defaults:
   team:
+    # Description of a team
+    description: ""
     # Level of privacy of a team. Can be "secret" or "closed"
     privacy: "closed"
+    # Notification setting of a team. Can be "notifications_enabled" or "notifications_disabled"
+    notification_setting: "notifications_enabled"

--- a/config/example/org.yaml
+++ b/config/example/org.yaml
@@ -10,3 +10,9 @@ org_name: example-org-on-github
 # List of owners of the GitHub organisation
 org_owners:
   - octocat
+
+# Default settings
+defaults:
+  team:
+    # Level of privacy of a team. Can be "secret" or "closed"
+    privacy: "closed"

--- a/config/example/teams/myteams.yaml
+++ b/config/example/teams/myteams.yaml
@@ -2,7 +2,14 @@
 # SPDX-License-Identifier: CC0-1.0
 
 # A Team with its name
-Maintainers:
+Project Team:
+  # Description of the team
+  description: "My awesome Maintainers team"
+  # Level of privacy of the team. Can be "secret" or "closed". Note: parent/child teams cannot be "secret"
+  privacy: "closed"
+  # Notification setting of the team.
+  # Can be "notifications_enabled" or "notifications_disabled"
+  notification_setting: "notifications_enabled"
   # Team maintainers, can add new people and change team settings
   maintainer:
     - octocat
@@ -13,12 +20,15 @@ Maintainers:
   # The repositories the team shall have access to with a certain permission
   # Can be one of: pull, triage, push, maintain, admin
   repos:
-    cool-repository: admin
-    other-repo: admin
+    cool-repository: push
+    other-repo: push
 
-Subproject:
+Project Maintainers:
+  # Make this a child team of the provided parent. Note: You should first
+  # describe parents in this file, then children
   parent: Maintainers
   member:
-    - user2
+    - octocat
   repos:
-    cool-repository: maintain
+    cool-repository: admin
+    other-repo: maintain

--- a/gh_org_mgr/_config.py
+++ b/gh_org_mgr/_config.py
@@ -85,7 +85,7 @@ def _read_config_file(file: str) -> dict:
     return config
 
 
-def parse_config_files(path: str) -> tuple[dict, dict, dict]:
+def parse_config_files(path: str) -> tuple[dict[str, str | dict[str, str]], dict, dict]:
     """Parse all relevant files in the configuration directory. Returns a tuple
     of org config, app config, and merged teams config"""
     # Find the relevant config files for app, org, and teams

--- a/gh_org_mgr/_gh_org.py
+++ b/gh_org_mgr/_gh_org.py
@@ -23,6 +23,7 @@ class GHorg:  # pylint: disable=too-many-instance-attributes
     gh: Github = None  # type: ignore
     org: Organization = None  # type: ignore
     gh_token: str = ""
+    default_settings: dict[str, dict[str, str]] = field(default_factory=dict)
     default_repository_permission: str = ""
     current_org_owners: list[NamedUser] = field(default_factory=list)
     configured_org_owners: list[str] = field(default_factory=list)
@@ -163,12 +164,19 @@ class GHorg:  # pylint: disable=too-many-instance-attributes
 
                     logging.info("Creating team '%s' with parent ID '%s'", team, parent_id)
                     if not dry:
-                        self.org.create_team(team, parent_team_id=parent_id)
+                        self.org.create_team(
+                            team,
+                            parent_team_id=parent_id,
+                            # Hardcode privacy as "secret" is not possible in child teams
+                            privacy="closed",
+                        )
 
                 else:
                     logging.info("Creating team '%s' without parent", team)
                     if not dry:
-                        self.org.create_team(team, privacy="closed")
+                        self.org.create_team(
+                            team, privacy=self.default_settings.get("team", {}).get("privacy", "")
+                        )
 
             else:
                 logging.debug("Team '%s' already exists", team)

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -106,7 +106,8 @@ def main():
                 "No GitHub organisation name configured in organisation settings. Cannot continue"
             )
             sys.exit(1)
-        org.configured_org_owners = cfg_org.get("org_owners")
+        org.configured_org_owners = cfg_org.get("org_owners", [])
+        org.default_settings = cfg_org.get("defaults", {})
 
         # Login to GitHub with token, get GitHub organisation
         org.login(cfg_org.get("org_name", ""), cfg_app.get("github_token", ""))

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -107,7 +107,9 @@ def main():
             )
             sys.exit(1)
         org.configured_org_owners = cfg_org.get("org_owners", [])
-        org.default_settings = cfg_org.get("defaults", {})
+        org.consolidate_team_config(
+            default_team_configs=cfg_org.get("defaults", {}).get("team", {})
+        )
 
         # Login to GitHub with token, get GitHub organisation
         org.login(cfg_org.get("org_name", ""), cfg_app.get("github_token", ""))

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -118,6 +118,8 @@ def main():
 
         # Create teams that aren't present at Github yet
         org.create_missing_teams(dry=args.dry)
+        # Configure general settings of teams
+        org.sync_current_teams_settings(dry=args.dry)
         # Synchronise organisation owners
         org.sync_org_owners(dry=args.dry, force=args.force)
         # Synchronise the team memberships

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -106,6 +106,7 @@ def main():
                 "No GitHub organisation name configured in organisation settings. Cannot continue"
             )
             sys.exit(1)
+        org.configured_org_owners = cfg_org.get("org_owners")
 
         # Login to GitHub with token, get GitHub organisation
         org.login(cfg_org.get("org_name", ""), cfg_app.get("github_token", ""))
@@ -115,9 +116,7 @@ def main():
         # Create teams that aren't present at Github yet
         org.create_missing_teams(dry=args.dry)
         # Synchronise organisation owners
-        org.sync_org_owners(
-            cfg_org_owners=cfg_org.get("org_owners"), dry=args.dry, force=args.force
-        )
+        org.sync_org_owners(dry=args.dry, force=args.force)
         # Synchronise the team memberships
         org.sync_teams_members(dry=args.dry)
         # Report about organisation members that do not belong to any team

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -133,7 +133,7 @@ def main():
         org.sync_repo_collaborator_permissions(dry=args.dry)
 
         # Debug output
-        logging.debug("Final dataclass:\n%s", org.df2json())
+        logging.debug("Final dataclass:\n%s", org.pretty_print_dataclass())
         org.ratelimit()
 
     # Setup Team command


### PR DESCRIPTION
 Synchronises parents, description, privacy, and notification settings for each configured team.

Introduces the possibility to define org-wide defaults for these settings.

This should be backwards-compatible. If e.g. descriptions are defined nowhere, the current value is kept.
One exception: If no parent is configured, but the team currently is a child, it will be made a top-level team.