### PR TITLE
Do not warn about org owners without team

### DIFF
--- a/gh_org_mgr/_gh_org.py
+++ b/gh_org_mgr/_gh_org.py
@@ -676,8 +676,10 @@ class GHorg:  # pylint: disable=too-many-instance-attributes, too-many-lines
         for _, team_attrs in self.current_teams.items():
             for member in team_attrs.get("members", {}):
                 all_team_members_lst.append(member)
-        # Also add users that have just been added to a team, and unify them
-        all_team_members: set[NamedUser] = set(all_team_members_lst + self.newly_added_users)
+        # Also add org owners and users that have just been added to a team, and unify them
+        all_team_members: set[NamedUser] = set(
+            all_team_members_lst + self.newly_added_users + self.current_org_owners
+        )
 
         # Find members that are in org_members but not team_members
         members_without_team = all_org_members.difference(all_team_members)


### PR DESCRIPTION
Fixes #65 

There might be good reasons why an org owner is not part of a team, so let's ignore this.