### PR TITLE
Add options to remove unconfigured teams and members

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Afterwards, the tool is executable with the command `gh-org-mgr`. The `--help` f
 
 Inside [`config/example`](./config/example), you can find an example configuration that shall help you to understand the structure:
 
-* `app.yaml`: Configuration necessary to run this tool
+* `app.yaml`: Configuration necessary to run this tool and controlling some behaviour
 * `org.yaml`: Organization-wide configuration
 * `teams/*.yaml`: Configuration concerning the teams of your organization.
 

--- a/config/example/app.yaml
+++ b/config/example/app.yaml
@@ -42,3 +42,6 @@ github_app_private_key: |
 # Remove members from organisation who are not member of any team or
 # organisation owners. Default: false
 remove_members_without_team: false
+
+# Delete teams that are not configured. Default: false
+delete_unconfigured_teams: false

--- a/config/example/app.yaml
+++ b/config/example/app.yaml
@@ -38,3 +38,7 @@ github_app_private_key: |
   D9zgrlJ8D4bxPrwDrCuXHY7s/1/uCX3K+mS7CWpybOcJY4XzsNznOYcMQzw22fxl
   u1ioG/s3Ahhd778VIjj5d32Xbjj8vbSFj8vJe5bBNblYbelWfETg
   -----END RSA PRIVATE KEY-----
+
+# Remove members from organisation who are not member of any team or
+# organisation owners. Default: false
+remove_members_without_team: false

--- a/gh_org_mgr/_gh_org.py
+++ b/gh_org_mgr/_gh_org.py
@@ -666,8 +666,11 @@ class GHorg:  # pylint: disable=too-many-instance-attributes, too-many-lines
                             team.name,
                         )
 
-    def get_members_without_team(self) -> None:
-        """Get all organisation members without any team membership"""
+    def get_members_without_team(
+        self, dry: bool = False, remove_members_without_team: bool = False
+    ) -> None:
+        """Get all organisation members without any team membership, and
+        optionally remove them"""
         # Combine org owners and org members
         all_org_members = set(self.org_members + self.current_org_owners)
 
@@ -685,11 +688,21 @@ class GHorg:  # pylint: disable=too-many-instance-attributes, too-many-lines
         members_without_team = all_org_members.difference(all_team_members)
 
         if members_without_team:
-            members_without_team_str = [user.login for user in members_without_team]
-            logging.warning(
-                "The following members of your GitHub organisation are not member of any team: %s",
-                ", ".join(members_without_team_str),
-            )
+            if remove_members_without_team:
+                for user in members_without_team:
+                    logging.info(
+                        "Removing user '%s' from organisation as they are not member of any team",
+                        user.login,
+                    )
+                    if not dry:
+                        self.org.remove_from_membership(user)
+            else:
+                members_without_team_str = [user.login for user in members_without_team]
+                logging.warning(
+                    "The following members of your GitHub organisation are not "
+                    "member of any team: %s",
+                    ", ".join(members_without_team_str),
+                )
 
     # --------------------------------------------------------------------------
     # Repos

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -129,6 +129,11 @@ def main():
         org.sync_current_teams_settings(dry=args.dry)
         # Synchronise the team memberships
         org.sync_teams_members(dry=args.dry)
+        # Report and act on teams that are not configured locally
+        org.get_unconfigured_teams(
+            dry=args.dry,
+            delete_unconfigured_teams=cfg_app.get("delete_unconfigured_teams", False),
+        )
         # Report and act on organisation members that do not belong to any team
         org.get_members_without_team(
             dry=args.dry,

--- a/gh_org_mgr/manage.py
+++ b/gh_org_mgr/manage.py
@@ -129,8 +129,11 @@ def main():
         org.sync_current_teams_settings(dry=args.dry)
         # Synchronise the team memberships
         org.sync_teams_members(dry=args.dry)
-        # Report about organisation members that do not belong to any team
-        org.get_members_without_team()
+        # Report and act on organisation members that do not belong to any team
+        org.get_members_without_team(
+            dry=args.dry,
+            remove_members_without_team=cfg_app.get("remove_members_without_team", False),
+        )
         # Synchronise the permissions of teams for all repositories
         org.sync_repo_permissions(dry=args.dry, ignore_archived=args.ignore_archived)
         # Remove individual collaborator permissions if they are higher than the one


### PR DESCRIPTION
Fixes #53 

* Optionally remove teams that are not configured locally
* Optionally remove members who are not member of any team

The behaviour can be controlled in `app.yaml`.