### PR TITLE
Fix KeyError when team becomes empty

### DIFF
--- a/gh_org_mgr/_stats.py
+++ b/gh_org_mgr/_stats.py
@@ -111,7 +111,7 @@ class OrgChanges:
     def update_repo(self, repo_name: str, **changes: bool | str | list[str]) -> None:
         """Update team changes."""
         # Initialise repo if not present
-        if repo_name not in self.teams:
+        if repo_name not in self.repos:
             self.repos[repo_name] = RepoChanges()
 
         implement_changes_into_class(dc_object=self.repos[repo_name], **changes)


### PR DESCRIPTION
In `OrgChanges.update_repo`, the guard condition initialising a new `RepoChanges` entry checked `self.teams` instead of `self.repos`. This caused a `KeyError` when a repository name did not coincide with any team name, most commonly triggered during collaborator permission synchronisation after a team became empty and its last member was removed.
